### PR TITLE
fix: default override issue

### DIFF
--- a/src/8_create_hashids_decode.sql
+++ b/src/8_create_hashids_decode.sql
@@ -170,7 +170,7 @@ CREATE OR REPLACE FUNCTION hashids.decode(
   in p_salt text,
   in p_min_hash_length integer,
   in p_alphabet text,
-  in p_zero_offset boolean)
+  in p_zero_offset boolean DEFAULT true)
   RETURNS bigint[] AS
 $$
     DECLARE

--- a/src/all_hashids.sql
+++ b/src/all_hashids.sql
@@ -754,7 +754,7 @@ CREATE OR REPLACE FUNCTION hashids.decode(
   in p_salt text,
   in p_min_hash_length integer,
   in p_alphabet text,
-  in p_zero_offset boolean)
+  in p_zero_offset boolean DEFAULT true)
   RETURNS bigint[] AS
 $$
     DECLARE


### PR DESCRIPTION
Fix default function argument override.

Otherwise it gives the following error on postgres 11:
```
cannot remove parameter defaults from existing function
```