### PR TITLE
fix: Allow for encoding bigint

### DIFF
--- a/src/4_create_hashids_hash.sql
+++ b/src/4_create_hashids_hash.sql
@@ -21,7 +21,7 @@ BEGIN
         --raise notice 'SUBSTRING(%, %, 1): %', p_alphabet, v_pos, (SUBSTRING(p_alphabet, v_pos, 1));
         --raise notice '% || % == %', SUBSTRING(p_alphabet, v_pos, 1), v_hash, SUBSTRING(p_alphabet, v_pos, 1) || v_hash;
         v_hash := SUBSTRING(p_alphabet, v_pos, 1) || v_hash;
-        p_input := CAST((p_input / v_alphabet_length) as int);
+        p_input := CAST((p_input / v_alphabet_length) as bigint);
         --raise notice 'p_input %', p_input;
         IF p_input <= 0 THEN
             EXIT;

--- a/src/6_create_hashids_encode_list.sql
+++ b/src/6_create_hashids_encode_list.sql
@@ -35,7 +35,7 @@ $$
         v_count int = array_length(p_numbers, 1);
         v_i int = 0;
         v_id int = 0;
-        v_number int;
+        v_number bigint;
         v_guardIndex int;
         v_guard char(1);
         v_halfLength int;

--- a/src/all_hashids.sql
+++ b/src/all_hashids.sql
@@ -280,7 +280,7 @@ BEGIN
         --raise notice 'SUBSTRING(%, %, 1): %', p_alphabet, v_pos, (SUBSTRING(p_alphabet, v_pos, 1));
         --raise notice '% || % == %', SUBSTRING(p_alphabet, v_pos, 1), v_hash, SUBSTRING(p_alphabet, v_pos, 1) || v_hash;
         v_hash := SUBSTRING(p_alphabet, v_pos, 1) || v_hash;
-        p_input := CAST((p_input / v_alphabet_length) as int);
+        p_input := CAST((p_input / v_alphabet_length) as bigint);
         --raise notice 'p_input %', p_input;
         IF p_input <= 0 THEN
             EXIT;
@@ -355,7 +355,7 @@ $$
         v_count int = array_length(p_numbers, 1);
         v_i int = 0;
         v_id int = 0;
-        v_number int;
+        v_number bigint;
         v_guardIndex int;
         v_guard char(1);
         v_halfLength int;


### PR DESCRIPTION
Internal functions were casting bigint to int which would cause an out of bounds error if an integer larger than int was passed.